### PR TITLE
Satisfy requirement for errors.Unwrap in ErrCollector

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -63,6 +63,12 @@ func (e *ErrCollector) Error() string {
 	return fmt.Sprintf("error at %s:%d #%d - %v", e.File, e.Line, e.Index, e.Err)
 }
 
+// Unwrap satisfies the requirement of `errors.Unwrap()`, to allow testing
+// ErrCollector with e.g. `errors.Is()` and `errors.As()`.
+func (e *ErrCollector) Unwrap() error {
+	return e.Err
+}
+
 // Panic causes the collector to panic if any error has been collected.
 //
 // This should be called in a defer:

--- a/errs_test.go
+++ b/errs_test.go
@@ -1,6 +1,7 @@
 package xmlwriter
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -60,4 +61,15 @@ func TestCollectorPanic(t *testing.T) {
 	}()
 	tt.Equals(t, ec, result)
 	tt.Pattern(t, `error at .*errs_test\.go.* #3 - yep`, ec.Error())
+}
+
+func TestCollectorUnwrap(t *testing.T) {
+	in := fmt.Errorf("yep")
+	ec := &ErrCollector{}
+	result := func() (err error) {
+		defer ec.Set(&err)
+		ec.Do(in)
+		return
+	}()
+	tt.Assert(t, errors.Is(result, in))
 }


### PR DESCRIPTION
This changes `ErrCollector` to satisfy the requirement of `errors.Unwrap`, introduced in Go 1.13, to allow testing an error with `errors.Is` and `errors.As`.