### PR TITLE
Upgrade CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        go_version:
+        - "1.14"
         # Allocation test fails on 1.15, but works on 1.16. Disabling 1.15 for
         # now.
-        go_version: ["1.14", "1.16", "1.17"]
+        - "1.16"
+        - "1.17"
         os: [ubuntu-latest, windows-latest, macOS-latest]
     
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,10 @@ jobs:
         # now.
         - "1.16"
         - "1.17"
+        - "1.18"
+        - "1.19"
+        # Quotes are important: 1.20 is not 1.2
+        - "1.20"
         os: [ubuntu-latest, windows-latest, macOS-latest]
     
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
+        go mod download
 
     - name: Test
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Set up Go ${{ matrix.go_version }}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go_version }}
       id: go


### PR DESCRIPTION
Upgrade GitHub Actions CI:
* add Go version 1.18, 1.19, 1.20
* upgrade actions/setup-go, actions/checkout