### PR TITLE
Remove file go.mod.fix

### DIFF
--- a/go.mod.fix
+++ b/go.mod.fix
@@ -1,5 +1,0 @@
-module github.com/shabbyrobe/xmlwriter
-
-go 1.13
-
-require golang.org/x/text v0.3.2


### PR DESCRIPTION
Remove `go.mod.fix` which was accidentaly added in ec87af3e7a4e24c672a10597712412ceaa89010c.